### PR TITLE
changed pacaur to pacman

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@ sudo dpkg -i gopass-1.7.2-linux-amd64.deb</code></pre>
 				<h3>
 					ArchLinux
 				</h3>
-				<pre><code>pacaur -S gopass</code></pre>
+				<pre><code>pacman -S gopass</code></pre>
 				<h3>
 					Gentoo
 				</h3>


### PR DESCRIPTION
Gopass is in the official Arch repos now, so installation via pacman is the way to go