### PR TITLE
replaced dead download links with new 1.8.4 links

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,8 +200,8 @@
 				<h3>
 					Debian and Ubuntu
 				</h3>
-        <pre><code>https://dl.bintray.com/gopasspw/gopass/pool/main/g/gopass/gopass-1.8.3-linux-amd64.deb
-sudo dpkg -i gopass-1.8.3-linux-amd64.deb</code></pre>
+        <pre><code>https://github.com/gopasspw/gopass/releases/download/v1.8.4/gopass-1.8.4-linux-amd64.deb
+sudo dpkg -i gopass-1.8.4-linux-amd64.deb</code></pre>
 				<h3>
 					ArchLinux
 				</h3>
@@ -228,10 +228,10 @@ dnf install gopass
 					Binary Download
 				</h3>
 				<p>
-        <a href="/gopass/releases/1.8.3/gopass-1.8.3-darwin-amd64.tar.gz" class="btn btn-primary">
+        <a href="https://github.com/gopasspw/gopass/releases/download/v1.8.4/gopass-1.8.4-darwin-amd64.tar.gz" class="btn btn-primary">
 						<i class="fa fa-download"></i> Download
 						<small>
-							(1.8.3)
+							(1.8.4)
 						</small>
 					</a>
 				</p>
@@ -241,7 +241,7 @@ dnf install gopass
 		<hr>
 
 		<h3>Other Operating Systems</h3>
-    Please visit <a href="https://github.com/gopasspw/gopass/releases/tag/v1.8.3/" target="_releases">https://github.com/gopasspw/gopass/releases/tag/v1.8.3/</a> for a list of binary releases
+    Please visit <a href="https://github.com/gopasspw/gopass/releases/latest" target="_releases">https://github.com/gopasspw/gopass/releases/latest</a> for a list of binary releases
 
 		<h3>From Source</h3>
     Run <code>go get github.com/gopasspw/gopass</code> to install gopass from source.


### PR DESCRIPTION
addresses issue [1042](https://github.com/gopasspw/gopass/issues/1042)