### PR TITLE
Update the code sample to install on debian/ubuntu

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@
 				<h3>
 					Debian and Ubuntu
 				</h3>
-        <pre><code>https://dl.bintray.com/gopasspw/gopass/pool/main/g/gopass/gopass-1.8.5-linux-amd64.deb
+        <pre><code>wget https://github.com/gopasspw/gopass/releases/download/v1.8.5/gopass-1.8.5-linux-amd64.deb
 sudo dpkg -i gopass-1.8.5-linux-amd64.deb</code></pre>
 				<h3>
 					ArchLinux


### PR DESCRIPTION
the code sample to install for debian/ubuntu just provides a url. this pr adds wget as a tool to actually download a file and replaces the dead link with the link to the github releases