### PR TITLE
doc(install): fix dpkg parameter filename

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@
 					Debian and Ubuntu
 				</h3>
 				<pre><code>wget https://github.com/gopasspw/gopass/releases/download/v1.9.0/gopass_1.9.0_linux_amd64.deb
-sudo dpkg -i gopass-1.9.0-linux-amd64.deb</code></pre>
+sudo dpkg -i gopass_1.9.0_linux_amd64.deb</code></pre>
 				<h3>
 					ArchLinux
 				</h3>


### PR DESCRIPTION
The installation steps for ubuntu & debian do not work if entered with copy & paste, as the downloaded filename is not the same in the second step.

This change fixes the filename passed to dpkg.