### PR TITLE
Gentoo: app-admin/gopass is in the main portage tree now

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,8 +209,7 @@ sudo dpkg -i gopass_1.9.2_linux_amd64.deb</code></pre>
 				<h3>
 					Gentoo
 				</h3>
-				<pre><code>layman -a go-overlay
-emerge -av gopass</code></pre>
+				<pre><code>emerge -av app-admin/gopass</code></pre>
         <h3>
           RedHat / CentOS
         </h3>


### PR DESCRIPTION
We don't need to add the go-overlay anymore.