### PR TITLE
Windows install: add missing gpg4win dependency

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,7 +252,8 @@ dnf install gopass</code></pre>
                         <h3>
                             Chocolatey
                         </h3>
-                        <pre><code>choco install gopass</code></pre>
+                        <pre><code>choco install gpg4win
+choco install gopass</code></pre>
                         <h3>
                             Scoop
                         </h3>

--- a/index.tpl
+++ b/index.tpl
@@ -252,7 +252,8 @@ dnf install gopass</code></pre>
                         <h3>
                             Chocolatey
                         </h3>
-                        <pre><code>choco install gopass</code></pre>
+                        <pre><code>choco install gpg4win
+choco install gopass</code></pre>
                         <h3>
                             Scoop
                         </h3>


### PR DESCRIPTION
Fix for gopasspw/gopass#2139