### PR TITLE
List Fedora installation instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,6 +215,10 @@
                         </h3>
                         <pre><code>emerge -av gopass</code></pre>
                         <h3>
+                          Fedora
+                        </h3>
+                        <pre><code>dnf install gopass</code></pre>
+                        <h3>
                           RedHat / CentOS
                         </h3>
                         <pre><code>dnf copr enable daftaupe/gopass

--- a/index.tpl
+++ b/index.tpl
@@ -215,6 +215,10 @@
                         </h3>
                         <pre><code>emerge -av gopass</code></pre>
                         <h3>
+                          Fedora
+                        </h3>
+                        <pre><code>dnf install gopass</code></pre>
+                        <h3>
                           RedHat / CentOS
                         </h3>
                         <pre><code>dnf copr enable daftaupe/gopass


### PR DESCRIPTION
As of https://fale.io/blog/2022/04/25/gopass-in-fedora it's available directly in Fedora.

Reflects https://github.com/gopasspw/gopass/pull/2197