### PR TITLE
Remove extra s in filename

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
 sudo dpkg -i gopass_1.14.10_linux_amd64.deb</code></pre>
                             </li>
                             <li>Using our <a href="https://packages.gopass.pw/repos/gopass/">APT repository</a>:
-                            <pre>curl https://packages.gopass.pw/repos/gopass/gopass-archive-keyring.gpg | sudo tee /usr/share/keyrings/gopasss-archive-keyring.gpg
+                            <pre>curl https://packages.gopass.pw/repos/gopass/gopass-archive-keyring.gpg | sudo tee /usr/share/keyrings/gopass-archive-keyring.gpg
 cat &lt;&lt; EOF | sudo tee /etc/apt/sources.list.d/gopass.sources
 Types: deb
 URIs: https://packages.gopass.pw/repos/gopass


### PR DESCRIPTION
The error causes apt setup to fail.